### PR TITLE
Add CSS files to the paths the hook is run on

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,22 +3,22 @@
     entry: biome ci --files-ignore-unknown=true --no-errors-on-unmatched
     language: node
     types: [text]
-    files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+    files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 -   id: biome-check
     name: biome check
     entry: biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
     language: node
     types: [text]
-    files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+    files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 -   id: biome-format
     name: biome format
     entry: biome format --write --files-ignore-unknown=true --no-errors-on-unmatched
     language: node
     types: [text]
-    files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+    files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 -   id: biome-lint
     name: biome lint
     entry: biome lint --write --files-ignore-unknown=true --no-errors-on-unmatched
     language: node
     types: [text]
-    files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+    files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ repos:
         entry: npx biome check --apply --files-ignore-unknown=true --no-errors-on-unmatched
         language: system
         types: [text]
-        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 ```
 
 The pre-commit option `files` is optional,


### PR DESCRIPTION
Biome 1.8.0 added support for linting and formatting CSS files. This adds CSS files to the list of file extensions that are passed to Biome via the pre-commit hook.