### PR TITLE
feat: use serial mode to reduce execution time

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,6 +5,7 @@
     language_version: lts
     types: [text]
     files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css|svelte|vue|astro|graphql|gql)$"
+    require_serial: true
 -   id: biome-check
     name: biome check
     entry: biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
@@ -12,6 +13,7 @@
     language_version: lts
     types: [text]
     files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css|svelte|vue|astro|graphql|gql)$"
+    require_serial: true
 -   id: biome-format
     name: biome format
     entry: biome format --write --files-ignore-unknown=true --no-errors-on-unmatched
@@ -19,6 +21,7 @@
     language_version: lts
     types: [text]
     files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css|svelte|vue|astro|graphql|gql)$"
+    require_serial: true
 -   id: biome-lint
     name: biome lint
     entry: biome lint --write --files-ignore-unknown=true --no-errors-on-unmatched
@@ -26,3 +29,4 @@
     language_version: lts
     types: [text]
     files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css|svelte|vue|astro|graphql|gql)$"
+    require_serial: true


### PR DESCRIPTION
By default, pre-commit spawns parallel processes for checking files. Biome is already fast, so parallelization adds little benefit but makes output harder to read by splitting summary statistics across processes.

This change ensures Biome runs serially to provide cleaner, combined output. Local benchmarks show Biome still completes quickly (~0.2s) without parallelization.

Before:

```
$ pre-commit run biome-check -a -v
biome check..............................................................Passed
- hook id: biome-check
- duration: 0.21s

Checked 25 files in 46ms. No fixes applied.
Checked 25 files in 63ms. No fixes applied.
Checked 25 files in 35ms. No fixes applied.
Checked 25 files in 65ms. No fixes applied.
Checked 25 files in 87ms. No fixes applied.
Checked 25 files in 89ms. No fixes applied.
Checked 25 files in 29ms. No fixes applied.
Checked 25 files in 69ms. No fixes applied.
Checked 25 files in 50ms. No fixes applied.
Checked 25 files in 59ms. No fixes applied.
```

After:

```
$ pre-commit run biome-check -a -v
biome check..............................................................Passed
- hook id: biome-check
- duration: 0.13s

Checked 250 files in 68ms. No fixes applied.
```

Note that the runtime actually drops, at least on my machine for this project. The cost of spawning lots of separate processes seems to be higher than actually linting the files.